### PR TITLE
Feature/(KAN-42) Add status column to complaints table

### DIFF
--- a/sources/dbcomplaints.sql
+++ b/sources/dbcomplaints.sql
@@ -6,7 +6,8 @@ CREATE TABLE PUBLIC_ENTITYS (
 CREATE TABLE COMPLAINTS (
     id_complaint INT NOT NULL,
     id_public_entity INT NOT NULL,
-    description VARCHAR(500)
+    description VARCHAR(500),
+    status TINYINT(1) DEFAULT 1 NOT NULL
 );
 
 ALTER TABLE PUBLIC_ENTITYS 
@@ -18,6 +19,14 @@ MODIFY id_complaint INT NOT NULL AUTO_INCREMENT PRIMARY KEY;
 ALTER TABLE COMPLAINTS
 ADD CONSTRAINT FK_COMPLAINT_PUBLIC_ENTITY
 FOREIGN KEY (id_public_entity) REFERENCES PUBLIC_ENTITYS(id_public_entity);
+
+-- Insert status column in case the table already exists
+ALTER TABLE COMPLAINTS
+ADD COLUMN status TINYINT(1) NOT NULL DEFAULT 1;
+
+ALTER TABLE COMPLAINTS
+MODIFY status TINYINT(1) NOT NULL DEFAULT 1
+CHECK (status IN (0,1));
 
 INSERT INTO PUBLIC_ENTITYS (id_public_entity, name) VALUES
 (1, 'Gobernación de Boyacá'),


### PR DESCRIPTION
## Description
- Added a `status` column (TINYINT(1), default 1) to the `COMPLAINTS` table in the database for logical deletion (inactivation).
- Updated backend logic so that deleting a complaint now sets `status = 0` instead of physically removing the record.
- Modified the complaints list and related queries to only display complaints where `status = 1`.
- Changes applied to: database schema (`dbcomplaints.sql`).

## Objective
- Enable logical deletion of complaints, allowing records to be marked as inactive instead of being permanently deleted.
- Improve data integrity and auditability by preserving complaint records even after deletion actions.

## Impact
- Users can no longer permanently delete complaints; instead, complaints are marked as inactive and hidden from the main list.
- The system now supports better data recovery and auditing, as inactive complaints remain in the database.
- No impact on other modules, but any direct queries to the `COMPLAINTS` table should now consider the `status` column to filter active records.
