### PR TITLE
feat : add status to complaints

### DIFF
--- a/sources/dbcomplaints.sql
+++ b/sources/dbcomplaints.sql
@@ -7,7 +7,8 @@ CREATE TABLE COMPLAINTS (
     id_complaint INT NOT NULL,
     id_public_entity INT NOT NULL,
     description VARCHAR(500),
-    status TINYINT(1) DEFAULT 1 NOT NULL
+    status TINYINT(1) DEFAULT 1 NOT NULL,
+    complaint_status ENUM('abierta', 'en_revision', 'cerrada') DEFAULT 'abierta' NOT NULL
 );
 
 ALTER TABLE PUBLIC_ENTITYS 
@@ -23,6 +24,10 @@ FOREIGN KEY (id_public_entity) REFERENCES PUBLIC_ENTITYS(id_public_entity);
 -- Insert status column in case the table already exists
 ALTER TABLE COMPLAINTS
 ADD COLUMN status TINYINT(1) NOT NULL DEFAULT 1;
+
+-- Add complaint_status column for complaint states
+ALTER TABLE COMPLAINTS
+ADD COLUMN complaint_status ENUM('abierta', 'en_revision', 'cerrada') DEFAULT 'abierta' NOT NULL;
 
 ALTER TABLE COMPLAINTS
 MODIFY status TINYINT(1) NOT NULL DEFAULT 1

--- a/src/controllers/complaintsController.js
+++ b/src/controllers/complaintsController.js
@@ -32,7 +32,7 @@ const knex = require('../config/db');
 exports.listComplaints = (req, res) => {
     knex('COMPLAINTS as c')
         .join('PUBLIC_ENTITYS as p', 'c.id_public_entity', 'p.id_public_entity')
-        .select('c.id_complaint', 'p.name as public_entity', 'c.description')
+        .select('c.id_complaint', 'p.name as public_entity', 'c.description', 'c.complaint_status')
         .where('c.status', 1)
         .then((results) => {
             res.render('complaints_list', { complaints: results });
@@ -91,17 +91,86 @@ exports.fileComplaint = (req, res) => {
 };
 
 exports.complaintsStats = (req, res) => {
-    knex('COMPLAINTS as c')
-        .join('PUBLIC_ENTITYS as p', 'c.id_public_entity', 'p.id_public_entity')
-        .select('p.name as public_entity')
-        .count('c.id_complaint as total_complaints')
-        .groupBy('p.id_public_entity', 'p.name')
-        .orderBy('total_complaints', 'desc')
-        .then((results) => {
-            res.render('complaints_stats', { stats: results });
+    Promise.all([
+        // Estadísticas por entidad
+        knex('COMPLAINTS as c')
+            .join('PUBLIC_ENTITYS as p', 'c.id_public_entity', 'p.id_public_entity')
+            .select('p.name as public_entity')
+            .count('c.id_complaint as total_complaints')
+            .where('c.status', 1)
+            .groupBy('p.id_public_entity', 'p.name')
+            .orderBy('total_complaints', 'desc'),
+        
+        // Estadísticas por estado de queja
+        knex('COMPLAINTS')
+            .select('complaint_status')
+            .count('id_complaint as total')
+            .where('status', 1)
+            .groupBy('complaint_status')
+    ])
+    .then(([entityStats, statusStats]) => {
+        res.render('complaints_stats', { 
+            stats: entityStats,
+            statusStats: statusStats
+        });
+    })
+    .catch(err => {
+        console.error(err);
+        res.status(500).send('Error al obtener estadísticas');
+    });
+};
+
+// Cambiar estado de queja con validación de contraseña
+exports.updateComplaintStatus = (req, res) => {
+    const { id_complaint, complaint_status, password } = req.body;
+    
+    // Validar datos requeridos
+    if (!id_complaint || !complaint_status || !password) {
+        return res.status(400).json({ 
+            success: false, 
+            message: 'Datos incompletos: se requiere ID de queja, nuevo estado y contraseña' 
+        });
+    }
+
+    // Validar estados permitidos
+    const allowedStatuses = ['abierta', 'en_revision', 'cerrada'];
+    if (!allowedStatuses.includes(complaint_status)) {
+        return res.status(400).json({ 
+            success: false, 
+            message: 'Estado no válido. Los estados permitidos son: abierta, en_revision, cerrada' 
+        });
+    }
+
+    // Validar contraseña
+    if (password !== DELETE_PASSWORD) {
+        return res.status(401).json({ 
+            success: false, 
+            message: 'Contraseña incorrecta' 
+        });
+    }
+
+    // Actualizar el estado de la queja
+    knex('COMPLAINTS')
+        .where('id_complaint', id_complaint)
+        .update({ complaint_status: complaint_status })
+        .then(count => {
+            if (count > 0) {
+                res.json({ 
+                    success: true, 
+                    message: `Estado de la queja actualizado a: ${complaint_status}` 
+                });
+            } else {
+                res.status(404).json({ 
+                    success: false, 
+                    message: 'Queja no encontrada' 
+                });
+            }
         })
         .catch(err => {
-            console.error(err);
-            res.status(500).send('Error al obtener estadísticas');
+            console.error('Error al actualizar estado de queja:', err);
+            res.status(500).json({ 
+                success: false, 
+                message: 'Error al actualizar el estado de la queja' 
+            });
         });
 };

--- a/src/routes/complaintsRoutes.js
+++ b/src/routes/complaintsRoutes.js
@@ -6,5 +6,6 @@ router.get('/list', complaintsController.listComplaints);
 router.post('/file', complaintsController.fileComplaint);
 router.get('/stats', complaintsController.complaintsStats);
 router.post('/delete', complaintsController.deleteComplaint);
+router.post('/update-status', complaintsController.updateComplaintStatus);
 
 module.exports = router;

--- a/src/views/complaints_list.ejs
+++ b/src/views/complaints_list.ejs
@@ -483,6 +483,14 @@
             .custom_table td:nth-of-type(2):before {
                 content: "Descripción";
             }
+
+            .custom_table td:nth-of-type(3):before {
+                content: "Estado";
+            }
+
+            .custom_table td:nth-of-type(4):before {
+                content: "Acciones";
+            }
         }
 
         .alert-info {
@@ -490,6 +498,37 @@
             text-align: center;
             margin: 20px auto;
             max-width: 500px;
+        }
+
+        /* Estilos para badges de estado */
+        .badge {
+            font-size: 0.9rem;
+            padding: 0.5rem 0.8rem;
+            border-radius: 8px;
+            font-weight: 600;
+        }
+
+        /* Mejorar el grupo de botones */
+        .btn-group .btn {
+            margin: 0 2px;
+        }
+
+        @media (max-width: 768px) {
+            .btn-group {
+                display: flex;
+                flex-direction: column;
+                gap: 5px;
+            }
+            
+            .btn-group .btn {
+                margin: 0;
+                font-size: 0.85rem;
+            }
+
+            .badge {
+                font-size: 0.8rem;
+                padding: 0.4rem 0.6rem;
+            }
         }
 
         table.dataTable {
@@ -561,6 +600,7 @@
                             <tr>
                                 <th class="custom_th">Entidad</th>
                                 <th class="custom_th">Descripción</th>
+                                <th class="custom_th">Estado de Queja</th>
                                 <th class="custom_th">Acciones</th>
                             </tr>
                         </thead>
@@ -573,10 +613,44 @@
                                     <td data-label="Descripción">
                                         <%= c.description %>
                                     </td>
+                                    <td data-label="Estado de Queja">
+                                        <% 
+                                        let statusClass = '';
+                                        let statusText = '';
+                                        switch(c.complaint_status) {
+                                            case 'abierta':
+                                                statusClass = 'badge bg-warning text-dark';
+                                                statusText = 'Abierta';
+                                                break;
+                                            case 'en_revision':
+                                                statusClass = 'badge bg-info text-white';
+                                                statusText = 'En Revisión';
+                                                break;
+                                            case 'cerrada':
+                                                statusClass = 'badge bg-success text-white';
+                                                statusText = 'Cerrada';
+                                                break;
+                                            default:
+                                                statusClass = 'badge bg-secondary';
+                                                statusText = 'Desconocido';
+                                        }
+                                        %>
+                                        <span class="<%= statusClass %>"><%= statusText %></span>
+                                    </td>
                                     <td data-label="Acciones">
-                                        <button class="btn btn-danger btn-sm delete-btn" data-id="<%= c.id_complaint %>" data-entity="<%= c.public_entity %>">
-                                            <i class="bi bi-trash"></i> Borrar
-                                        </button>
+                                        <div class="btn-group" role="group">
+                                            <button class="btn btn-primary btn-sm change-status-btn" 
+                                                    data-id="<%= c.id_complaint %>" 
+                                                    data-entity="<%= c.public_entity %>"
+                                                    data-current-status="<%= c.complaint_status %>">
+                                                <i class="bi bi-arrow-repeat"></i> Cambiar Estado
+                                            </button>
+                                            <button class="btn btn-danger btn-sm delete-btn" 
+                                                    data-id="<%= c.id_complaint %>" 
+                                                    data-entity="<%= c.public_entity %>">
+                                                <i class="bi bi-trash"></i> Borrar
+                                            </button>
+                                        </div>
                                     </td>
                                 </tr>
                             <% }) %>
@@ -618,6 +692,38 @@
             </div>
         </div>
 
+        <!-- Modal para cambiar estado de queja -->
+        <div class="modal fade" id="statusModal" tabindex="-1" aria-labelledby="statusModalLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="statusModalLabel">Cambiar Estado de Queja</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Cerrar"></button>
+                    </div>
+                    <div class="modal-body">
+                        <form id="statusForm">
+                            <input type="hidden" id="status-complaint-id" name="id_complaint">
+                            <div class="mb-3">
+                                <label for="complaint-status" class="form-label">Nuevo Estado:</label>
+                                <select class="form-select" id="complaint-status" name="complaint_status" required>
+                                    <option value="">Selecciona un estado</option>
+                                    <option value="abierta">Abierta</option>
+                                    <option value="en_revision">En Revisión</option>
+                                    <option value="cerrada">Cerrada</option>
+                                </select>
+                            </div>
+                            <div class="mb-3">
+                                <label for="status-password" class="form-label">Contraseña para cambiar estado:</label>
+                                <input type="password" class="form-control" id="status-password" name="password" required>
+                            </div>
+                            <div id="status-error" class="text-danger mb-2" style="display:none;"></div>
+                            <button type="submit" class="btn btn-primary">Cambiar Estado</button>
+                        </form>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
         <script>
@@ -627,13 +733,35 @@
         let deleteError = document.getElementById('delete-error');
         let deleteIdInput = document.getElementById('delete-complaint-id');
 
+        // Modal y lógica de cambio de estado
+        let statusModal = new bootstrap.Modal(document.getElementById('statusModal'));
+        let statusForm = document.getElementById('statusForm');
+        let statusError = document.getElementById('status-error');
+        let statusIdInput = document.getElementById('status-complaint-id');
+        let statusSelect = document.getElementById('complaint-status');
+
         document.addEventListener('click', function(e) {
+            // Manejar click en botón de borrar
             if (e.target.closest('.delete-btn')) {
                 const btn = e.target.closest('.delete-btn');
                 deleteIdInput.value = btn.getAttribute('data-id');
                 deleteError.style.display = 'none';
                 deleteForm.reset();
                 deleteModal.show();
+            }
+
+            // Manejar click en botón de cambiar estado
+            if (e.target.closest('.change-status-btn')) {
+                const btn = e.target.closest('.change-status-btn');
+                statusIdInput.value = btn.getAttribute('data-id');
+                const currentStatus = btn.getAttribute('data-current-status');
+                
+                // Limpiar selección anterior
+                statusSelect.value = '';
+                statusError.style.display = 'none';
+                document.getElementById('status-password').value = '';
+                
+                statusModal.show();
             }
         });
 
@@ -666,6 +794,50 @@
             .catch(() => {
                 deleteError.textContent = 'Error al borrar la queja';
                 deleteError.style.display = 'block';
+            });
+        });
+
+        statusForm.addEventListener('submit', function(e) {
+            e.preventDefault();
+            const id = statusIdInput.value;
+            const newStatus = statusSelect.value;
+            const password = document.getElementById('status-password').value;
+            
+            fetch('/complaints/update-status', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ 
+                    id_complaint: id, 
+                    complaint_status: newStatus, 
+                    password 
+                })
+            })
+            .then(res => res.json())
+            .then(data => {
+                if (data.success) {
+                    statusModal.hide();
+                    let statusText = '';
+                    switch(newStatus) {
+                        case 'abierta': statusText = 'Abierta'; break;
+                        case 'en_revision': statusText = 'En Revisión'; break;
+                        case 'cerrada': statusText = 'Cerrada'; break;
+                    }
+                    Swal.fire({
+                        icon: 'success',
+                        title: 'Estado actualizado',
+                        text: `El estado de la queja se cambió a: ${statusText}`,
+                        confirmButtonColor: '#2296c7'
+                    }).then(() => {
+                        location.reload();
+                    });
+                } else {
+                    statusError.textContent = data.message || 'Error al cambiar el estado';
+                    statusError.style.display = 'block';
+                }
+            })
+            .catch(() => {
+                statusError.textContent = 'Error al cambiar el estado de la queja';
+                statusError.style.display = 'block';
             });
         });
         function onCaptchaSuccess(token) {

--- a/src/views/complaints_stats.ejs
+++ b/src/views/complaints_stats.ejs
@@ -241,6 +241,54 @@
             white-space: nowrap !important;
             border: 0 !important;
         }
+
+        /* Estilos para las tarjetas de estado */
+        .status-stats-section {
+            margin-bottom: 2rem;
+        }
+        
+        .status-stats-section h3 {
+            color: #10B981;
+            font-weight: 600;
+            text-align: center;
+            margin-bottom: 1.5rem;
+        }
+        
+        .status-stats-section .card {
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+            border-radius: 12px;
+            height: 100%;
+        }
+        
+        .status-stats-section .card:hover {
+            transform: translateY(-5px);
+            box-shadow: 0 8px 25px rgba(0,0,0,0.15) !important;
+        }
+        
+        .status-stats-section .card-body {
+            padding: 1.5rem;
+        }
+        
+        .status-stats-section h4 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            margin: 0.5rem 0;
+        }
+        
+        @media (max-width: 768px) {
+            .status-stats-section .card-body {
+                padding: 1rem;
+            }
+            
+            .status-stats-section h4 {
+                font-size: 2rem;
+            }
+            
+            .status-stats-section h3 {
+                font-size: 1.5rem;
+                margin-bottom: 1rem;
+            }
+        }
     </style>
 </head>
 
@@ -283,6 +331,54 @@
                     <h2><%= totalComplaints %></h2>
                     <p>Total de quejas registradas</p>
                 </div>
+
+                <!-- Estadísticas por estado de queja -->
+                <% if (statusStats && statusStats.length > 0) { %>
+                <section class="status-stats-section mb-4">
+                    <h3 class="mb-3">Distribución por Estado de Queja</h3>
+                    <div class="row justify-content-center">
+                        <% statusStats.forEach(statusStat => { %>
+                            <div class="col-md-4 col-sm-6 mb-3">
+                                <div class="card border-0 shadow-sm">
+                                    <div class="card-body text-center">
+                                        <% 
+                                        let statusClass = '';
+                                        let statusIcon = '';
+                                        let statusText = '';
+                                        switch(statusStat.complaint_status) {
+                                            case 'abierta':
+                                                statusClass = 'text-warning';
+                                                statusIcon = '⚠️';
+                                                statusText = 'Abiertas';
+                                                break;
+                                            case 'en_revision':
+                                                statusClass = 'text-info';
+                                                statusIcon = '🔍';
+                                                statusText = 'En Revisión';
+                                                break;
+                                            case 'cerrada':
+                                                statusClass = 'text-success';
+                                                statusIcon = '✅';
+                                                statusText = 'Cerradas';
+                                                break;
+                                            default:
+                                                statusClass = 'text-secondary';
+                                                statusIcon = '❓';
+                                                statusText = 'Desconocido';
+                                        }
+                                        %>
+                                        <div class="<%= statusClass %> mb-2" style="font-size: 2rem;">
+                                            <%= statusIcon %>
+                                        </div>
+                                        <h4 class="<%= statusClass %>"><%= statusStat.total %></h4>
+                                        <p class="card-text text-muted mb-0"><%= statusText %></p>
+                                    </div>
+                                </div>
+                            </div>
+                        <% }) %>
+                    </div>
+                </section>
+                <% } %>
 
                 <section class="stats-table-section" aria-labelledby="table-title">
                     <h2 id="table-title" class="sr-only">Tabla de estadísticas por entidad</h2>


### PR DESCRIPTION
## Description  
Introduced a new workflow for managing and tracking the status of complaints.  

- **Database & Backend**  
  - Added a new `complaint_status` ENUM column in the `COMPLAINTS` table (`abierta`, `en_revision`, `cerrada`, default `abierta`).  
  - Exposed `complaint_status` in complaint listings and statistics.  
  - Implemented `updateComplaintStatus` controller with password validation and allowed status transitions.  
  - Created a new `/update-status` route for status updates.  

- **Frontend/UI**  
  - Updated complaints list view to display complaint status with styled badges.  
  - Added “Change Status” modal for secure status updates.  
  - Enhanced statistics view with a visual distribution of complaints by status, including styled cards and icons.  

---

## Goal  
Provide a clear way to track and update the lifecycle of complaints. Improve transparency for users, allow administrators to manage complaints securely, and ensure the system reflects accurate statistics by complaint status.  

---

## Impact  
- **Users:** Gain visibility into the current status of complaints and a way to interactively update them.  
- **System:** More accurate complaint lifecycle tracking and enhanced statistics.  
- **Risks:** Requires validation of the new status transitions; potential issues if database migrations are not applied correctly. Password validation flow must be tested thoroughly to avoid access problems.  
