### PR TITLE
Feature/[KAN-51] Implement captcha token

### DIFF
--- a/src/views/complaints_list.ejs
+++ b/src/views/complaints_list.ejs
@@ -840,6 +840,37 @@
                 statusError.style.display = 'block';
             });
         });
+
+        // --- CAPTCHA LOCALSTORAGE ---
+        const CAPTCHA_KEY = 'captcha_token';
+        const CAPTCHA_TIME_KEY = 'captcha_token_time';
+        const CAPTCHA_EXPIRATION_MINUTES = 30;
+
+        function isCaptchaValid() {
+            const token = localStorage.getItem(CAPTCHA_KEY);
+            const time = localStorage.getItem(CAPTCHA_TIME_KEY);
+            if (!token || !time) return false;
+            const now = Date.now();
+            const diff = (now - parseInt(time, 10)) / 1000 / 60;
+            return diff < CAPTCHA_EXPIRATION_MINUTES;
+        }
+
+        function showComplaintsList() {
+            document.querySelector('.captcha-container').style.display = 'none';
+            document.getElementById('complaints-container').style.display = 'block';
+            if ($('.custom_table').length && !$.fn.DataTable.isDataTable('.custom_table')) {
+                $('.custom_table').DataTable({
+                    paging: true,
+                    pageLength: 5,
+                    lengthChange: false,
+                    searching: false,
+                    info: false,
+                    ordering: false,
+                    responsive: true
+                });
+            }
+        }
+
         function onCaptchaSuccess(token) {
             fetch('/verify-captcha', {
                 method: 'POST',
@@ -849,18 +880,9 @@
                 .then(res => res.json())
                 .then(data => {
                     if (data.success) {
-                        document.querySelector('.captcha-container').style.display = 'none';
-                        document.getElementById('complaints-container').style.display = 'block';
-
-                        $('.custom_table').DataTable({
-                            paging: true,
-                            pageLength: 5,  // Menos registros por página en móviles
-                            lengthChange: false,
-                            searching: false,
-                            info: false,
-                            ordering: false,
-                            responsive: true
-                        });
+                        localStorage.setItem(CAPTCHA_KEY, token);
+                        localStorage.setItem(CAPTCHA_TIME_KEY, Date.now().toString());
+                        showComplaintsList();
                     } else {
                         alert('Verificación fallida. Por favor, intenta de nuevo.');
                         grecaptcha.reset();
@@ -872,6 +894,12 @@
                     grecaptcha.reset();
                 });
         }
+
+        window.addEventListener('DOMContentLoaded', function() {
+            if (isCaptchaValid()) {
+                showComplaintsList();
+            }
+        });
 
         // Ajustar el reCAPTCHA al tamaño de pantalla
         function adjustRecaptcha() {


### PR DESCRIPTION
## Description
This pull request implements client-side storage of the Google reCAPTCHA token using localStorage to enhance the user experience when accessing the complaints list. When a user successfully completes the captcha, the token and its timestamp are saved in localStorage. On subsequent visits, if the token is still valid (within 30 minutes), the captcha is bypassed and the complaints list is shown immediately, eliminating the need for the user to solve the captcha again within that period. The logic is implemented in the frontend JavaScript of `complaints_list.ejs` and does not require backend changes.

## Goal
The main objectives of this implementation are to reduce friction for users who frequently consult the complaints list, minimize repetitive captcha challenges, and streamline the user flow by leveraging browser storage. This approach maintains security by enforcing a 30-minute expiration window for the stored token, ensuring that users are periodically re-verified as human without excessive inconvenience.

## Impact
This change improves usability by allowing users to access the complaints list multiple times within a 30-minute window without re-solving the captcha, resulting in a smoother and faster experience. The system now checks localStorage for a valid captcha token before displaying the captcha widget, and only prompts for verification if the token is missing or expired. There are no changes to backend logic or database schema, and no impact on other modules. Security is preserved by enforcing token expiration, but it is important to note that this approach relies on client-side storage, which can be cleared by the user or affected by browser privacy settings.