### PR TITLE
Docs/(KAN-61) Add version history to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
+## Changelog
+
+
+### [0.0.2] - 2025-09-24
+#### Added
+- **Delete complaints with admin password**: Admins can securely delete complaints by providing a valid administrator password, ensuring only authorized removals.
+- **Change complaint status**: The status of each complaint (e.g., pending, resolved, closed) can be updated by authorized users or admins, supporting workflow management.
+- **Add comments to complaints**: Users and/or admins can add comments to individual complaints, enabling discussion, clarification, or follow-up on each case.
+
+### [0.0.1] - 2025-08-19
+#### Added
+- **Add complaints**: Users can submit new complaints through the web interface, providing details such as the entity and description.
+- **List complaints**: All complaints are displayed in a dedicated list view, allowing users to browse and review submitted complaints.
+- **List complaint reports**: A report view aggregates and displays complaint statistics for analysis.
 # Project Complaints
 
 This project is a web application for complaint management and visualization, developed as part of a Software Engineering course. The project implements a clean, decoupled architecture following SOLID principles.


### PR DESCRIPTION
## Description
Added a version history (changelog) section to the beginning of the README.
Documented all major features and changes for versions 0.0.1 and 0.0.2.
Provided clear, detailed descriptions for each feature in both versions.
Ensured the changelog uses a standard, GitHub-friendly format for easy tracking.
## Goal
To provide clear version tracking and transparency for all users and contributors.
Make it easy to understand what features and changes are included in each release.
Improve project documentation and maintainability by following best practices for open source projects.
## Impact
Users and contributors can now quickly see the evolution of the project and the features available in each version.
The changelog at the top of the README increases visibility and accessibility of version information.
No impact on application functionality or codebase; this is a documentation-only change.
Sets a standard for future version documentation and release notes.