### PR TITLE
Fix/(KAN-54) Disable search in the complaint statistics table

### DIFF
--- a/src/views/complaints_stats.ejs
+++ b/src/views/complaints_stats.ejs
@@ -449,7 +449,7 @@
                     paging: true,
                     pageLength: DATA_TABLE_CONFIG.DEFAULT_PAGE_LENGTH,
                     lengthChange: false,
-                    searching: true,
+                    searching: false,
                     info: false,
                     ordering: true,
                     order: [[1, 'desc']], // Ordenar por número de quejas descendente


### PR DESCRIPTION
## Description
The search/filter functionality of the complaints statistics table in the `complaints_stats.ejs` page was removed.  
The specific change was modifying the DataTable configuration by switching the `searching` parameter from `true` to `false` in the `initializeDataTable()` function.  
This modification completely removes the search field that used to appear above the entity statistics table.

## Goal
Simplify the user interface of the statistics page by removing unnecessary elements.  
The search filter did not provide significant functional value on a page mainly intended to display a general summary of statistics by entity, where users typically need to see all data at a glance rather than search for specific entities.

## Impact
**Positive:**
- Cleaner interface focused on statistics visualization  
- Less visual distraction for users  
- More straightforward experience when reviewing the complaints summary by entity  
