### PR TITLE
Feature/(KAN-115) Fix Session Status

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -19,7 +19,7 @@ User.init({
     allowNull: false 
   },
   session_status: { 
-    type: DataTypes.ENUM('active', 'inactive', 'expired'), 
+    type: DataTypes.ENUM('active', 'inactive'), 
     allowNull: false, 
     defaultValue: 'inactive' 
   },


### PR DESCRIPTION
# Description
This pull request updates the session_status field definition in src/models/user.js by removing the 'expired' value from its ENUM type. The field now only accepts 'active' and 'inactive' as valid states. This change aligns the user session model with the current authentication logic, which no longer utilizes the 'expired' status for session tracking.

# Goal
The main goal of this update is to maintain consistency between the data model and the active session management logic implemented in the authentication system. Since 'expired' sessions are now handled as 'inactive', this simplification avoids confusion, ensures database integrity, and streamlines session state handling across services.

# Impact
This change improves data consistency by eliminating an unused ENUM value and reducing potential discrepancies between backend logic and the database schema. It is a non-breaking modification, as the 'expired' state was deprecated and no longer referenced in the codebase. The only consideration is that any legacy records with 'expired' as their status will need migration to 'inactive' to ensure model validation continuity.