### PR TITLE
Feature/(KAN-113) Fix correct spelling of 'PUBLIC_ENTITYS' to 'PUBLIC_ENTITIES' 

### DIFF
--- a/migrations/20251012035135-create-public-entities.js
+++ b/migrations/20251012035135-create-public-entities.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
-    await queryInterface.createTable('PUBLIC_ENTITYS', {
+    await queryInterface.createTable('PUBLIC_ENTITIES', {
       id_public_entity: {
         type: Sequelize.INTEGER,
         primaryKey: true,
@@ -25,7 +25,7 @@ module.exports = {
       }
     });
 
-    await queryInterface.bulkInsert('PUBLIC_ENTITYS', [
+    await queryInterface.bulkInsert('PUBLIC_ENTITIES', [
       { id_public_entity: 1, name: 'Gobernación de Boyacá' },
       { id_public_entity: 2, name: 'Secretaría de Salud de Boyacá' },
       { id_public_entity: 3, name: 'INDEPORTES Boyacá' },
@@ -34,6 +34,6 @@ module.exports = {
     ]);
   },
   down: async (queryInterface) => {
-    await queryInterface.dropTable('PUBLIC_ENTITYS');
+    await queryInterface.dropTable('PUBLIC_ENTITIES');
   }
 };

--- a/migrations/20251012035150-create-complaints.js
+++ b/migrations/20251012035150-create-complaints.js
@@ -13,7 +13,7 @@ module.exports = {
         type: Sequelize.INTEGER,
         allowNull: false,
         references: {
-          model: 'PUBLIC_ENTITYS',
+          model: 'PUBLIC_ENTITIES',
           key: 'id_public_entity'
         },
         onUpdate: 'CASCADE',

--- a/src/models/entity.js
+++ b/src/models/entity.js
@@ -10,7 +10,7 @@ Entity.init({
 }, {
   sequelize,
   modelName: 'Entity',
-  tableName: 'PUBLIC_ENTITYS',
+  tableName: 'PUBLIC_ENTITIES',
   timestamps: false
 });
 

--- a/src/repositories/complaintsRepository.js
+++ b/src/repositories/complaintsRepository.js
@@ -87,7 +87,7 @@ class ComplaintsRepository {
         const [results] = await Complaint.sequelize.query(`
             SELECT p.name as public_entity, COUNT(c.id_complaint) as total_complaints
             FROM COMPLAINTS c
-            JOIN PUBLIC_ENTITYS p ON c.id_public_entity = p.id_public_entity
+            JOIN PUBLIC_ENTITIES p ON c.id_public_entity = p.id_public_entity
             WHERE c.status = 1
             GROUP BY p.id_public_entity, p.name
             ORDER BY total_complaints DESC


### PR DESCRIPTION
# Description

This pull request standardizes the database naming convention for public entity tables across the system.
The following changes were implemented:

Migrations: Renamed the table from PUBLIC_ENTITYS to PUBLIC_ENTITIES in 20251012035135-create-public-entities.js, ensuring a grammatically correct and consistent naming scheme.

References updated: Adjusted the foreign key reference in 20251012035150-create-complaints.js to point to PUBLIC_ENTITIES instead of PUBLIC_ENTITYS.

Model layer: Updated src/models/entity.js to use the new table name (PUBLIC_ENTITIES).

Repository layer: Modified SQL queries in src/repositories/complaintsRepository.js to reflect the updated table name in joins and aggregations.

# Goal

The primary goal is to correct the table name convention and maintain consistency across the data model, codebase, and database schema.
This update ensures alignment between Sequelize migrations, model definitions, and repository queries, avoiding potential runtime errors and mismatches during future migrations or queries.

# Impact

This change improves code readability, standardization, and database consistency without altering existing functionality.
The migration will drop and recreate the affected table (PUBLIC_ENTITIES), but it maintains the same structure and data seed.
Since all dependent components have been updated, the change is non-breaking at runtime once the database schema is migrated successfully.

The only consideration is that environments with legacy data (still under PUBLIC_ENTITYS) will require a migration or data transfer before deployment to avoid missing references.