### PR TITLE
Feature(KAN-132): remove reCAPTCHA verification endpoint and axios import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 require('dotenv').config(); // Carga variables desde .env
 const path = require('path');
-const axios = require('axios');
 
 
 // (Knex removed, now using Sequelize models directly in repositories/services)
@@ -32,39 +31,7 @@ app.use('/', loginRoutes);
 
 
 // Importar constantes
-const { HTTP_STATUS, DEFAULT_PORT } = require('./config/constants');
-
-// Ruta para verificar el token de Google reCAPTCHA (v2)
-app.post('/verify-captcha', async (req, res) => {
-    try {
-        const token = req.body.token;
-        if (!token) {
-            return res.status(HTTP_STATUS.BAD_REQUEST).json({ success: false, error: 'Token no enviado' });
-        }
-        const secretKey = process.env.RECAPTCHA_SECRET;
-        const response = await axios.post('https://www.google.com/recaptcha/api/siteverify', null, {
-            params: {
-                secret: secretKey,
-                response: token,
-                remoteip: req.ip
-            }
-        });
-        const data = response.data;
-        console.log('Respuesta de Google reCAPTCHA v2:', data);
-        if (data.success) {
-            res.json({ success: true, message: 'Verificación exitosa' });
-        } else {
-            res.json({
-                success: false,
-                error: 'Verificación fallida',
-                'error-codes': data['error-codes']
-            });
-        }
-    } catch (err) {
-        console.error('Error en verify-captcha:', err);
-    res.status(HTTP_STATUS.INTERNAL_ERROR).json({ success: false, error: 'Error interno en verify-captcha' });
-    }
-});
+const { DEFAULT_PORT } = require('./config/constants');
 
 // Exportar la app (para testing con Jest o supertest)
 module.exports = app;


### PR DESCRIPTION
## Description

This pull request removes the legacy /verify-captcha endpoint from index.js, including all related logic for Google reCAPTCHA validation and error handling. The axios import was also deleted from the file, as it was only used within the removed endpoint. The axios dependency remains in package.json because it is still required by authService.js for communication with the authentication microservice.

## Goal

The purpose of this change is to eliminate obsolete backend code associated with reCAPTCHA verification, which is no longer part of the system’s authentication flow. This cleanup contributes to codebase maintainability and reduces unused logic in the main server entry point.

## Impact

This modification removes 33 lines of unused code and slightly simplifies the main server logic. It has no effect on current system behavior or functionality, as the reCAPTCHA verification process was already deprecated. Risk level is minimal, and no additional configuration or testing is required beyond standard regression checks.