### PR TITLE
Feature(KAN-134): remove reCAPTCHA JavaScript validation logic

### DIFF
--- a/src/views/complaints_list.ejs
+++ b/src/views/complaints_list.ejs
@@ -1209,23 +1209,7 @@
             }
         }
 
-        // --- CAPTCHA LOCALSTORAGE ---
-        const CAPTCHA_KEY = 'captcha_token';
-        const CAPTCHA_TIME_KEY = 'captcha_token_time';
-        const CAPTCHA_EXPIRATION_MINUTES = 30;
-
-        function isCaptchaValid() {
-            const token = localStorage.getItem(CAPTCHA_KEY);
-            const time = localStorage.getItem(CAPTCHA_TIME_KEY);
-            if (!token || !time) return false;
-            const now = Date.now();
-            const diff = (now - parseInt(time, 10)) / 1000 / 60;
-            return diff < CAPTCHA_EXPIRATION_MINUTES;
-        }
-
         function showComplaintsList() {
-            document.querySelector('.captcha-container').style.display = 'none';
-            document.getElementById('complaints-container').style.display = 'block';
             if ($('.custom_table').length && !$.fn.DataTable.isDataTable('.custom_table')) {
                 const table = $('.custom_table').DataTable({
                     paging: true,


### PR DESCRIPTION
## Description

This pull request removes all client-side validation logic related to reCAPTCHA from the complaints_list.ejs file. The commented section // --- CAPTCHA LOCALSTORAGE ---, the constants CAPTCHA_KEY, CAPTCHA_TIME_KEY, and CAPTCHA_EXPIRATION_MINUTES, and the entire isCaptchaValid() function were deleted. Additionally, the showComplaintsList() function was simplified by removing two DOM manipulation lines related to the captcha.

## Goal

The goal of this change is to complete the removal of deprecated reCAPTCHA logic from the frontend code. This cleanup improves code clarity and ensures that no residual references to reCAPTCHA remain within the client-side validation flow.

## Impact

This update streamlines the complaints list JavaScript logic, reducing unnecessary code and potential confusion for future maintenance. There is no impact on current functionality, as captcha validation was already disabled. The change contributes to a cleaner and more maintainable frontend structure.