### PR TITLE
Feature/(KAN-135) remove recaptcha js callbacks

### DIFF
--- a/src/views/complaints_list.ejs
+++ b/src/views/complaints_list.ejs
@@ -1388,47 +1388,6 @@
                 commentError.style.display = 'block';
             });
         });
-        function onCaptchaSuccess(token) {
-            fetch('/verify-captcha', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ token: token })
-            })
-                .then(res => res.json())
-                .then(data => {
-                    if (data.success) {
-                        localStorage.setItem(CAPTCHA_KEY, token);
-                        localStorage.setItem(CAPTCHA_TIME_KEY, Date.now().toString());
-                        showComplaintsList();
-                    } else {
-                        alert('Verificación fallida. Por favor, intenta de nuevo.');
-                        grecaptcha.reset();
-                    }
-                })
-                .catch(err => {
-                    console.error('Error:', err);
-                    alert('Error al verificar. Por favor, intenta de nuevo.');
-                    grecaptcha.reset();
-                });
-        }
-
-        window.addEventListener('DOMContentLoaded', function() {
-            if (isCaptchaValid()) {
-                showComplaintsList();
-            }
-        });
-
-        // Ajustar el reCAPTCHA al tamaño de pantalla
-        function adjustRecaptcha() {
-            if (window.innerWidth <= 768) {
-                document.querySelector('.g-recaptcha').style.transform = 'scale(0.85)';
-            } else {
-                document.querySelector('.g-recaptcha').style.transform = 'scale(1)';
-            }
-        }
-
-        window.addEventListener('resize', adjustRecaptcha);
-        window.addEventListener('load', adjustRecaptcha);
 
         // Función para verificar la sesión sin usar localStorage directamente
         async function verifySession() {


### PR DESCRIPTION
## Description
This pull request removes all remaining JavaScript logic associated with reCAPTCHA from the complaints_list.ejs file. The onCaptchaSuccess(token) function (24 lines), the DOMContentLoaded event listener containing captcha validation (5 lines), and the adjustRecaptcha() function (7 lines) were deleted. Additionally, two event listeners (resize and load) used for adjusting the reCAPTCHA widget, along with one related comment, were removed.

## Goal
The goal of this change is to finalize the cleanup of deprecated reCAPTCHA callback logic from the complaints list UI. By removing unnecessary functions and event bindings, the codebase becomes more maintainable and free from unused dependencies.

## Impact
This update eliminates 41 lines of obsolete JavaScript, improving readability and reducing complexity in the complaints list view. There is no impact on the application’s behavior or user experience since the reCAPTCHA system was already deactivated. The change contributes to a cleaner, lighter, and more maintainable frontend code structure.