### PR TITLE
Feature(KAN-136): remove reCAPTCHA CSS styles

### DIFF
--- a/src/views/complaints_list.ejs
+++ b/src/views/complaints_list.ejs
@@ -286,42 +286,6 @@
             word-wrap: break-word;
         }
 
-        .captcha-container {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            margin: 30px auto;
-            padding: 20px;
-            background-color: #fff;
-            border-radius: 10px;
-            box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-            max-width: 400px;
-            width: 90%;
-        }
-
-        .captcha-wrapper {
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            width: 100%;
-        }
-
-        .captcha-message {
-            text-align: center;
-            margin-bottom: 20px;
-            color: #6c757d;
-            font-size: 1.1rem;
-            line-height: 1.4;
-        }
-
-        .g-recaptcha {
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            transform-origin: 0 0;
-        }
-
         /* ========== MEDIA QUERIES ========== */
         @media screen and (max-width: 992px) {
             .container {
@@ -380,21 +344,6 @@
                 height: 60px;
                 font-size: 1.8rem;
                 margin-bottom: 15px;
-            }
-
-            .captcha-container {
-                margin: 20px auto;
-                padding: 15px;
-                width: 95%;
-            }
-
-            .captcha-message {
-                font-size: 0.95rem;
-                margin-bottom: 15px;
-            }
-
-            .g-recaptcha {
-                transform: scale(0.9);
             }
 
             .custom_table {
@@ -463,21 +412,6 @@
                 border-radius: 15px;
             }
 
-            .captcha-container {
-                margin: 15px auto;
-                padding: 12px;
-                border-radius: 8px;
-            }
-
-            .captcha-message {
-                font-size: 0.9rem;
-                margin-bottom: 12px;
-            }
-
-            .g-recaptcha {
-                transform: scale(0.85);
-            }
-
             .custom_table {
                 border-radius: 15px;
             }
@@ -542,10 +476,6 @@
             .dataTables_wrapper .dataTables_paginate .paginate_button {
                 padding: 4px 8px !important;
                 font-size: 0.75rem !important;
-            }
-
-            .captcha-message {
-                font-size: 0.85rem;
             }
         }
 


### PR DESCRIPTION
## Description

This pull request removes all CSS rules associated with reCAPTCHA from the complaints_list.ejs file. The main style definitions for .captcha-container, .captcha-wrapper, .captcha-message, and .g-recaptcha were deleted. Additionally, all responsive adjustments within the media queries for @media (max-width: 992px), @media (max-width: 768px), and @media (max-width: 480px) were also removed.

## Goal

The goal of this change is to complete the visual cleanup of reCAPTCHA components by eliminating all obsolete CSS definitions. This ensures that no unused styles remain in the codebase after the removal of the reCAPTCHA UI and related scripts.

## Impact

This update removes 70 lines of redundant CSS, reducing file size and improving maintainability. There is no functional or visual impact on the application, as the corresponding HTML and JavaScript for reCAPTCHA were already removed in previous updates. The result is a cleaner and more efficient frontend code structure.